### PR TITLE
visibility が followers なノートを学習しないオプションを追加

### DIFF
--- a/config-sample.json
+++ b/config-sample.json
@@ -25,6 +25,7 @@
 	"markovSpeaking": {
 		"allowLearn": true,
 		"allowLearnCW": true,
+		"allowLearnVisFollowers": true,
 		"blocked": [
 			"somebody@example.com"
 		],

--- a/src/config.ts
+++ b/src/config.ts
@@ -130,4 +130,7 @@ config.visibility = getProperVisibilityProperty(config)
 if (config.database.attenuationRate == undefined)
 	config.database.attenuationRate = 0
 
+if (config.markov.allowLearnVisFollowers == undefined)
+	config.markov.allowLearnVisFollowers = true
+
 export default config as Config

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ type Config = {
 	markovSpeaking: {
 		allowLearn: boolean
 		allowLearnCW: boolean
+		allowLearnVisFollowers: boolean
 		/*
 		 * If you want this bot not to learn the message
 		 * from a specified account, you can add an account

--- a/src/modules/markov-speaking/index.ts
+++ b/src/modules/markov-speaking/index.ts
@@ -92,7 +92,10 @@ export default class MarkovSpeakingModule implements IModule {
 	public onNote(note: any) {
 		this.database.updateSave()
 		let bad = this.filter.isBad(note.text)
-		if (!bad && !(!config.markovSpeaking.allowLearnCW && note.cw)) this.learn(note.user, note.text)
+		if (!bad &&
+			!(!config.markovSpeaking.allowLearnCW && note.cw) &&
+			!(!config.markovSpeaking.allowLearnVisFollowers && note.visibility === 'followers')
+			) this.learn(note.user, note.text)
 		console.log(
 			`${isBlocked(note.user) ? "><" : ""}${bad ? "B* " : ""}|${
 			note.user.name


### PR DESCRIPTION
visibility が followers なノートを学習しないオプションを追加しました。

意図としては、フォロワー限定公開のノートがこのbotを介して、部分的かつ発信元が隠された状態でありながらもフォロワーでないユーザーにも公開される恐れがあるからです。

発生確率は低いものの考えられる例としては、
（`attenuationRate`を指定せずに）学習データが完全に空になった後に、TLに流れてきたフォロワー限定投稿を学習し、ユーザーからのメンションにそれとそっくりのテキストを返してしまう例です。

（if のところのインデント、変だったら指摘してくれるとうれしい。）