### PR TITLE
Fix types originally meant an array of string

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -162,26 +162,18 @@
                     "type": "boolean"
                 },
                 "blocked": {
-                    "items": [
-                        {
-                            "type": "string"
-                        }
-                    ],
-                    "maxItems": 1,
-                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "filtering": {
                     "type": "boolean"
                 },
                 "wordFilterFiles": {
-                    "items": [
-                        {
-                            "type": "string"
-                        }
-                    ],
-                    "maxItems": 1,
-                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    },
                     "type": "array"
                 },
                 "wordFilterLog": {
@@ -216,13 +208,9 @@
             "type": "array"
         },
         "op": {
-            "items": [
-                {
-                    "type": "string"
-                }
-            ],
-            "maxItems": 1,
-            "minItems": 1,
+            "items": {
+                "type": "string"
+            },
             "type": "array"
         },
         "postMaxCharacterCount": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,16 +36,16 @@ export type Config = {
 		 * from a specified account, you can add an account
 		 * into this list to prevent from learning their posts.
 		 */
-		blocked: [string]
+		blocked: string[]
 		filtering: boolean
 		wordFilterURL: string
-		wordFilterFiles: [string]
+		wordFilterFiles: string[]
 		wordFilterLog: boolean
 	}
 	math: {
 		size: number
 	}
-	op: [string]
+	op: string[]
 	database: {
 		path: string
 		type: Database


### PR DESCRIPTION
## 概要

Config の型定義のうち、string の配列の型が付くべきである部分をそのように修正します。

## 背景

`[string]` は `string` 型の要素を 1 つだけ含む配列を示す型であって、想定していたものは `string` 型の要素を含む配列 `string[]` である。
昔に型定義を書いたときは何を思ったのか前者を使っていた。