### PR TITLE
Add `schema` script to package.json

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci
 
       - name: Generate schema
-        run: npx typescript-json-schema ./src/config.ts Config -o config-schema.json
+        run: npm run schema
 
       - name: Check diff
         run: git diff --exit-code config-schema.json

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "index.js",
 	"scripts": {
 		"start": "node ./built",
+		"schema": "typescript-json-schema ./src/config.ts Config -o config-schema.json",
 		"build": "tsc && node meta.js",
 		"lint": "eslint .",
 		"lint:prettier": "prettier --check '**/*.{js,ts}'",


### PR DESCRIPTION
## 概要

現在は schema.yml にベタ書きされている schema 生成部分を、package.json の `"schema"` script として追加します。

schema.yml を見ないと schema の生成方法がわからなくなってしまっているのを解消する意図です。