### PR TITLE
Fix `asciimath-to-latex` import

### DIFF
--- a/src/modules/math.ts
+++ b/src/modules/math.ts
@@ -2,7 +2,7 @@ import IModule from "../module"
 import MessageLike from "../message-like"
 import Ai from "../ai"
 import config from "../config"
-const asciimathToLaTeX = require("asciimath-to-latex")
+import asciimathToLaTeX from "asciimath-to-latex"
 const mj = require("mathjax-node")
 const svg2png = require("svg2png")
 


### PR DESCRIPTION
## 概要

`/math atol x^2` のような入力を与えると以下のようなスタックトレースを出して落ちるのを修正します。

```
/Users/yusuke/Documents/GitHub/botot2/built/modules/math.js:81
                        msg.reply("\\(" + asciimathToLaTeX(cmd.slice(2).join(" ")) + "\\)");
                                          ^

TypeError: asciimathToLaTeX is not a function
    at MathModule.<anonymous> (/Users/yusuke/Documents/GitHub/botot2/built/modules/math.js:81:43)
    at Generator.next (<anonymous>)
    at /Users/yusuke/Documents/GitHub/botot2/built/modules/math.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/Users/yusuke/Documents/GitHub/botot2/built/modules/math.js:4:12)
    at MathModule.onCommand (/Users/yusuke/Documents/GitHub/botot2/built/modules/math.js:75:16)
    at Ai.<anonymous> (/Users/yusuke/Documents/GitHub/botot2/built/ai.js:234:46)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/yusuke/Documents/GitHub/botot2/built/ai.js:5:58)
```

## 原因

#27 でアップデートされ、`module.exports` 経由ではなく `exports.default` 経由で当該の関数が公開されるようになったため？