### PR TITLE
Bump up Node.js version to v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
 
       - name: Install Renovate CLI

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
 
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"xml2js": "^0.4.22"
 			},
 			"devDependencies": {
-				"@types/node": "16.18.3",
+				"@types/node": "18.11.10",
 				"@types/node-fetch": "2.6.2",
 				"@types/ws": "8.5.3",
 				"@types/xml2js": "0.4.11",
@@ -39,6 +39,9 @@
 				"prettier": "2.7.1",
 				"tslib": "2.4.0",
 				"typescript-json-schema": "0.55.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -206,9 +209,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.18.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-			"integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
+			"version": "18.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
+			"integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
 			"dev": true
 		},
 		"node_modules/@types/node-fetch": {
@@ -3844,6 +3847,12 @@
 				"typescript-json-schema": "bin/typescript-json-schema"
 			}
 		},
+		"node_modules/typescript-json-schema/node_modules/@types/node": {
+			"version": "16.18.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+			"integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw==",
+			"dev": true
+		},
 		"node_modules/typescript-json-schema/node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4421,9 +4430,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.18.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-			"integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
+			"version": "18.11.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
+			"integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
 			"dev": true
 		},
 		"@types/node-fetch": {
@@ -7170,6 +7179,12 @@
 				"yargs": "^17.1.1"
 			},
 			"dependencies": {
+				"@types/node": {
+					"version": "16.18.4",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+					"integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw==",
+					"dev": true
+				},
 				"cliui": {
 					"version": "8.0.1",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
-		"@types/node": "16.18.3",
+		"@types/node": "18.11.10",
 		"@types/node-fetch": "2.6.2",
 		"@types/ws": "8.5.3",
 		"@types/xml2js": "0.4.11",
@@ -47,5 +47,8 @@
 		"typescript": "^4.0.0",
 		"ws": "^8.0.0",
 		"xml2js": "^0.4.22"
+	},
+	"engines": {
+		"node": ">=18.0.0 <19.0.0"
 	}
 }


### PR DESCRIPTION
# 概要

closes #82
closes #86
related #87

botot2 を動かすための Node.js のバージョン要求を `>=18.0.0 <19.0.0` に設定します。
また、これに対応するため GitHub Actions で CI を実行する際に Node.js v18 系を取得するように変更します。

加えて、`@types/node` のバージョンを `18.11.10` に更新します。
