### PR TITLE
Remove `node-fetch` and its type definitions from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
 				"mathjax-node": "^2.1.1",
 				"moment": "^2.29.2",
 				"node-cabocha": "0.0.5",
-				"node-fetch": "^2.6.7",
 				"reconnecting-websocket": "^4.2.0",
 				"request-promise-native": "^1.0.8",
 				"svg2png": "^4.1.1",
@@ -26,7 +25,6 @@
 			},
 			"devDependencies": {
 				"@types/node": "18.11.10",
-				"@types/node-fetch": "2.6.2",
 				"@types/ws": "8.5.3",
 				"@types/xml2js": "0.4.11",
 				"eslint": "8.28.0",
@@ -41,7 +39,7 @@
 				"typescript-json-schema": "0.55.0"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=18.0.0 <19.0.0"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -213,16 +211,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
 			"integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
 			"dev": true
-		},
-		"node_modules/@types/node-fetch": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-			"integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-			"dev": true,
-			"dependencies": {
-				"@types/node": "*",
-				"form-data": "^3.0.0"
-			}
 		},
 		"node_modules/@types/ws": {
 			"version": "8.5.3",
@@ -1745,20 +1733,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-			"dev": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fs-extra": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
@@ -2684,44 +2658,6 @@
 			"version": "7.10.14",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.14.tgz",
 			"integrity": "sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA=="
-		},
-		"node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/node-fetch/node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-		},
-		"node_modules/node-fetch/node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-		},
-		"node_modules/node-fetch/node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
 		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
@@ -4435,16 +4371,6 @@
 			"integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
 			"dev": true
 		},
-		"@types/node-fetch": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
-			"integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*",
-				"form-data": "^3.0.0"
-			}
-		},
 		"@types/ws": {
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
@@ -5597,17 +5523,6 @@
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
-		"form-data": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fs-extra": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
@@ -6327,35 +6242,6 @@
 					"version": "7.10.14",
 					"resolved": "https://registry.npmjs.org/@types/node/-/node-7.10.14.tgz",
 					"integrity": "sha512-29GS75BE8asnTno3yB6ubOJOO0FboExEqNJy4bpz0GSmW/8wPTNL4h9h63c6s1uTrOopCmJYe/4yJLh5r92ZUA=="
-				}
-			}
-		},
-		"node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"requires": {
-				"whatwg-url": "^5.0.0"
-			},
-			"dependencies": {
-				"tr46": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-				},
-				"webidl-conversions": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-				},
-				"whatwg-url": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-					"requires": {
-						"tr46": "~0.0.3",
-						"webidl-conversions": "^3.0.0"
-					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@types/node": "18.11.10",
-		"@types/node-fetch": "2.6.2",
 		"@types/ws": "8.5.3",
 		"@types/xml2js": "0.4.11",
 		"eslint": "8.28.0",
@@ -39,7 +38,6 @@
 		"mathjax-node": "^2.1.1",
 		"moment": "^2.29.2",
 		"node-cabocha": "0.0.5",
-		"node-fetch": "^2.6.7",
 		"reconnecting-websocket": "^4.2.0",
 		"request-promise-native": "^1.0.8",
 		"svg2png": "^4.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import config from "./config";
 import Ai from "./ai";
 import Modulez from "./modules";
-import fetch from "node-fetch";
 import IModule from "./module";
 import { User } from "./misskey";
 

--- a/src/modules/markov-speaking/word-filter.ts
+++ b/src/modules/markov-speaking/word-filter.ts
@@ -1,6 +1,5 @@
 import * as XML from "xml2js";
 import config from "../../config";
-import fetch from "node-fetch";
 import * as fs from "fs";
 
 export default class WordFilter {


### PR DESCRIPTION
# 概要

closes #87

`node-fetch` と `@types/node-fetch` を依存パッケージから削除し、Node.js v18 系から標準で利用できるようになった `fetch` 関数を利用するようにします。

## 動作確認

* Node.js v18.12.1 が入った macOS Monterey version 12.6 が動くマシンで `npm run build` 後に `node ./built` を実行してタイムラインを WebSocket で購読するところまで動くところ
    * `I am name(@username)!` の表示がログに正常に出ている、すなわち fetch でインスタンスからボット自身のユーザー情報を取得できていることが確認できた
    * https://github.com/private-yusuke/botot2/blob/096d3026b2428aaf1c28f29c3d307fe66c8952ee/src/index.ts#L20