### PR TITLE
Bump up to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "botot2",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"description": "A chatbot for Misskey with Markov chain",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
# 概要

botot2 が Node.js v18 系で実行されることを要求するようになり、これは大きな変更であると考えたので、メジャーバージョンを更新します。