### PR TITLE
Reduce number of PRs created for `@types/node` by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,11 @@
   "timezone": "Asia/Tokyo",
   "packageRules": [
     {
-      "matchPackageNames": ["@types/node"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
       "schedule": ["every 2 weeks on monday"]
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
+  "extends": ["config:base"],
+  "timezone": "Asia/Tokyo",
+  "packageRules": [
+    {
+      "matchPackageNames": ["@types/node"],
+      "schedule": ["every 2 weeks on monday"]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
-      "schedule": ["every 2 weeks on monday"]
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
# 概要

closes #95 

Renovate が `@types/node` に限って隔週で PR を出してもらうように設定を変更します。

## 動作確認

実際の Renovate の動作は確認していませんが、`npx --package=renovate -c 'renovate-config-validator'` をローカルで実行して `renovate.json` が valid であることを確認しました