### PR TITLE
Set `Content-Type: application/json` as a default value in HTTP request header`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ async function main() {
     body: JSON.stringify({
       i: config.i,
     }),
-    headers: config.headers,
+    headers: {
+      "Content-Type": "application/json",
+      ...config.headers,
+    },
   });
   let me = (await tmp.json()) as User; // Force convert to misskey.User
   console.log(`I am ${me.name}(@${me.username})!`);

--- a/src/misskey/index.ts
+++ b/src/misskey/index.ts
@@ -32,7 +32,10 @@ function api(endpoint: string, body?: any) {
   return fetch(url, {
     method: "POST",
     body: data,
-    headers: config.headers,
+    headers: {
+      "Content-Type": "application/json",
+      ...config.headers,
+    },
   });
 }
 


### PR DESCRIPTION
# 概要

closes #118

接続先サーバーへの HTTP リクエストを実施する際に header に `Content-Type: application/json` をデフォルトで指定するようにします。

## 動作確認

https://github.com/private-yusuke/botot2/issues/118#issuecomment-1423965547 にあるようなワークアラウンドをしていない手元の動作環境で botot2 を起動し、v13 のインスタンスにてメンションを受け取った際の返信ができること