### PR TITLE
Instantiate modules with an instance of `Ai`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "botot2",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "A chatbot for Misskey with Markov chain",
 	"main": "index.js",
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,16 +22,8 @@ async function main() {
   console.log(`I am ${me.name}(@${me.username})!`);
   console.log(`Version: ${config.version}(${config.revision})`);
   me.host = config.host;
-  const modules: IModule[] = [];
-  Modulez.forEach((M) => {
-    const m = new M(ai);
-    if (config.modules.indexOf(m.name) >= 0) modules.push(m);
-  });
-  modules.sort((a, b) => {
-    return b.priority - a.priority;
-  });
 
-  ai = new Ai(me, modules);
+  ai = new Ai(me);
 }
 
 process.on("SIGINT", async () => {

--- a/src/modules/admin.ts
+++ b/src/modules/admin.ts
@@ -37,12 +37,14 @@ export default class AdminModule implements IModule {
   public async onCommand(msg: MessageLike, cmd: string[]): Promise<boolean> {
     if (cmd[0] == "info") {
       let res = `\`\`\`
-Modules: ${this.ai.modules.map((i) => `${i.name}(${i.priority})`).join(", ")}
+Modules: ${this.ai.loadedModules
+        .map((i) => `${i.name}(${i.priority})`)
+        .join(", ")}
 Uptime: ${this.getUptime()}
 ${process.title} ${process.version} ${process.arch} ${process.platform}
 Version: ${config.version}(${config.revision})
 `;
-      res += this.ai.modules
+      res += this.ai.loadedModules
         .filter(assertProperty("info"))
         .map((i) => i.info())
         .join("\n");
@@ -51,7 +53,7 @@ Version: ${config.version}(${config.revision})
       return true;
     } else if (cmd[0] == "help") {
       let res = "```\n";
-      this.ai.modules.forEach((v) => {
+      this.ai.loadedModules.forEach((v) => {
         if (v.commands) {
           v.commands.forEach((c) => {
             if (c.desc) res += `/${c.name}: ${c.desc}\n`;


### PR DESCRIPTION
# 概要

closes #97

各モジュールの constructor で `Ai` のインスタンスを渡すようにし、`Ai` の初期化中にモジュールのインスタンスを生成するようにします。
これによって、`AdminModule` で提供される `/help` と `/info` が動作するようになります。
https://github.com/private-yusuke/botot2/issues/97#issue-1491308071 の「解決方法」にある手法を採用したものです。

また、botot2 のバージョンを 4.0.1 に上げます。